### PR TITLE
geom_alt props

### DIFF
--- a/data/421/171/019/421171019.geojson
+++ b/data/421/171/019/421171019.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"CG",
     "wof:created":1459008879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ad05279ef7c98918b6ff63a0a43a7c8",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421171019,
-    "wof:lastmodified":1566639008,
+    "wof:lastmodified":1582349477,
     "wof:name":"Loandjili",
     "wof:parent_id":85670049,
     "wof:placetype":"county",

--- a/data/421/180/023/421180023.geojson
+++ b/data/421/180/023/421180023.geojson
@@ -571,6 +571,9 @@
     },
     "wof:country":"CG",
     "wof:created":1459009242,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b5b76c4f92781e2229eec677cfd0972",
     "wof:hierarchy":[
         {
@@ -582,7 +585,7 @@
         }
     ],
     "wof:id":421180023,
-    "wof:lastmodified":1566639007,
+    "wof:lastmodified":1582349477,
     "wof:name":"Brazzaville",
     "wof:parent_id":1092012549,
     "wof:placetype":"locality",

--- a/data/421/184/609/421184609.geojson
+++ b/data/421/184/609/421184609.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"CG",
     "wof:created":1459009416,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"53cf010c9e65884075aeb01d8e2253c2",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421184609,
-    "wof:lastmodified":1566639008,
+    "wof:lastmodified":1582349477,
     "wof:name":"Nkayi District",
     "wof:parent_id":85670027,
     "wof:placetype":"county",

--- a/data/421/204/287/421204287.geojson
+++ b/data/421/204/287/421204287.geojson
@@ -105,6 +105,9 @@
     },
     "wof:country":"CG",
     "wof:created":1459010179,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0d1238b39322488f127dfe5900a79c07",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":421204287,
-    "wof:lastmodified":1566639006,
+    "wof:lastmodified":1582349476,
     "wof:name":"Louvakou (Loubomo)",
     "wof:parent_id":85670059,
     "wof:placetype":"county",

--- a/data/856/325/41/85632541.geojson
+++ b/data/856/325/41/85632541.geojson
@@ -1110,7 +1110,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1184,7 +1183,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1582349469,
+    "wof:lastmodified":1583229429,
     "wof:name":"Republic of Congo",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/325/41/85632541.geojson
+++ b/data/856/325/41/85632541.geojson
@@ -1110,6 +1110,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1164,6 +1165,11 @@
     },
     "wof:country":"CG",
     "wof:country_alpha3":"COG",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"2fca18834a08fab9fdfc946920ffcb35",
     "wof:hierarchy":[
         {
@@ -1178,7 +1184,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566638621,
+    "wof:lastmodified":1582349469,
     "wof:name":"Republic of Congo",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/700/23/85670023.geojson
+++ b/data/856/700/23/85670023.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Cuvette-Ouest Department"
     },
     "wof:country":"CG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bfe1bc7a8007fa21d6682950ce4bae4b",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566638619,
+    "wof:lastmodified":1582349468,
     "wof:name":"Cuvette-Ouest",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/27/85670027.geojson
+++ b/data/856/700/27/85670027.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Bouenza Department"
     },
     "wof:country":"CG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e7170008e2fe7418921f92df51a5d1f",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566638616,
+    "wof:lastmodified":1582349466,
     "wof:name":"Bouenza",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/31/85670031.geojson
+++ b/data/856/700/31/85670031.geojson
@@ -287,6 +287,9 @@
         "wd:id":"Q863554"
     },
     "wof:country":"CG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7081f5d9d2bbb33316f9f1d0e6275554",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566638617,
+    "wof:lastmodified":1582349467,
     "wof:name":"Likouala",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/35/85670035.geojson
+++ b/data/856/700/35/85670035.geojson
@@ -275,6 +275,9 @@
         "wk:page":"Sangha Department (Republic of the Congo)"
     },
     "wof:country":"CG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fcaae86ffc826b97442855f4ff8ecd4f",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566638615,
+    "wof:lastmodified":1582349466,
     "wof:name":"Sangha",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/41/85670041.geojson
+++ b/data/856/700/41/85670041.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Pool Department"
     },
     "wof:country":"CG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e02a2bc34fea728a45e6fb6d1f2bb4c",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566638618,
+    "wof:lastmodified":1582349467,
     "wof:name":"Pool",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/45/85670045.geojson
+++ b/data/856/700/45/85670045.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Cuvette Department"
     },
     "wof:country":"CG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eab65acca504d495e6378f4f6ef3f38f",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566638616,
+    "wof:lastmodified":1582349466,
     "wof:name":"Cuvette",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/49/85670049.geojson
+++ b/data/856/700/49/85670049.geojson
@@ -217,6 +217,9 @@
         "wk:page":"Kouilou Department"
     },
     "wof:country":"CG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9848c1bfe8b2dd0ea76d6247d0113b91",
     "wof:hierarchy":[
         {
@@ -232,7 +235,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566638620,
+    "wof:lastmodified":1582349468,
     "wof:name":"Kouilou",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/53/85670053.geojson
+++ b/data/856/700/53/85670053.geojson
@@ -293,6 +293,9 @@
         "wk:page":"L\u00e9koumou Department"
     },
     "wof:country":"CG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5080ea497b3accac9146164b3824e070",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566638617,
+    "wof:lastmodified":1582349467,
     "wof:name":"L\u00e9koumou",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/59/85670059.geojson
+++ b/data/856/700/59/85670059.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Niari Department"
     },
     "wof:country":"CG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f1f4501f0500365ee6a49ee2562fe213",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566638614,
+    "wof:lastmodified":1582349465,
     "wof:name":"Niari",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/63/85670063.geojson
+++ b/data/856/700/63/85670063.geojson
@@ -281,6 +281,9 @@
         "wk:page":"Plateaux Department (Republic of the Congo)"
     },
     "wof:country":"CG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a097f176adea237391b7706d4437d128",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566638618,
+    "wof:lastmodified":1582349467,
     "wof:name":"Plateaux",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/67/85670067.geojson
+++ b/data/856/700/67/85670067.geojson
@@ -544,6 +544,9 @@
         "wd:id":"Q3844"
     },
     "wof:country":"CG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b0da0dbcd23220edbdf43c6d32050b65",
     "wof:hierarchy":[
         {
@@ -559,7 +562,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566638616,
+    "wof:lastmodified":1582349466,
     "wof:name":"Brazzaville",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/71/85670071.geojson
+++ b/data/856/700/71/85670071.geojson
@@ -226,6 +226,9 @@
         "wk:page":"Kouilou Department"
     },
     "wof:country":"CG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9cebb8166956a9f5972e6b9e97e4f251",
     "wof:hierarchy":[
         {
@@ -241,7 +244,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566638620,
+    "wof:lastmodified":1582349468,
     "wof:name":"Pointe Noire",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/857/718/29/85771829.geojson
+++ b/data/857/718/29/85771829.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q13127755"
     },
     "wof:country":"CG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4b7c9a1bd37d23d7b804be263c838246",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1534379250,
+    "wof:lastmodified":1582349464,
     "wof:name":"Losange",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.