### PR TITLE
Update properties of megacities

### DIFF
--- a/data/421/180/023/421180023.geojson
+++ b/data/421/180/023/421180023.geojson
@@ -567,6 +567,7 @@
     "wof:concordances":{
         "gn:id":2260535,
         "gp:id":1279685,
+        "ne:id":1159150993,
         "qs_pg:id":274192,
         "wd:id":"Q3844",
         "wk:page":"Brazzaville"
@@ -587,7 +588,8 @@
         }
     ],
     "wof:id":421180023,
-    "wof:lastmodified":1607390875,
+    "wof:lastmodified":1608688178,
+    "wof:megacity":1,
     "wof:name":"Brazzaville",
     "wof:parent_id":1092012549,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary