### PR TITLE
cg concordances, placetype local, and more

### DIFF
--- a/data/109/201/237/7/1092012377.geojson
+++ b/data/109/201/237/7/1092012377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147224,
-    "geom:area_square_m":1814815662.515269,
+    "geom:area_square_m":1814815326.117093,
     "geom:bbox":"13.265077,-4.805362,13.765083,-4.28564",
     "geom:latitude":-4.511063,
     "geom:longitude":13.541584,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"CG.BO.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897038,
-    "wof:geomhash":"d00d512d235539365c41b7dfc0d4605d",
+    "wof:geomhash":"ad6c5ff2f376f2655d11d16887df5bd4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092012377,
-    "wof:lastmodified":1627521988,
+    "wof:lastmodified":1695886459,
     "wof:name":"Boko-Songho",
     "wof:parent_id":85670027,
     "wof:placetype":"county",

--- a/data/109/201/241/9/1092012419.geojson
+++ b/data/109/201/241/9/1092012419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.240191,
-    "geom:area_square_m":2962897453.325965,
+    "geom:area_square_m":2962897453.325982,
     "geom:bbox":"12.5943481936,-4.39035927761,13.3621238978,-3.52",
     "geom:latitude":-3.960039,
     "geom:longitude":12.937713,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"CG.BO.LO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897040,
-    "wof:geomhash":"065a296d7bedb8d51f058ed62b8ebaff",
+    "wof:geomhash":"db39a94acbca932d4bbf536584279cd5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1092012419,
-    "wof:lastmodified":1566638969,
+    "wof:lastmodified":1695886316,
     "wof:name":"Loudima",
     "wof:parent_id":85670027,
     "wof:placetype":"county",

--- a/data/109/201/243/3/1092012433.geojson
+++ b/data/109/201/243/3/1092012433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081525,
-    "geom:area_square_m":1005378669.08069,
+    "geom:area_square_m":1005378708.166942,
     "geom:bbox":"13.406103,-4.354563,13.866095,-4.009097",
     "geom:latitude":-4.192953,
     "geom:longitude":13.602023,
@@ -98,9 +98,10 @@
     "wof:concordances":{
         "hasc:id":"CG.BO.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897041,
-    "wof:geomhash":"088f7410c5f69c3e91077379b0422487",
+    "wof:geomhash":"8a751521c7e9f1221394579dc8b0e920",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092012433,
-    "wof:lastmodified":1636501770,
+    "wof:lastmodified":1695886796,
     "wof:name":"Madingou",
     "wof:parent_id":85670027,
     "wof:placetype":"county",

--- a/data/109/201/247/7/1092012477.geojson
+++ b/data/109/201/247/7/1092012477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029414,
-    "geom:area_square_m":362638292.122458,
+    "geom:area_square_m":362638309.852969,
     "geom:bbox":"13.683149,-4.516094,13.953462,-4.309684",
     "geom:latitude":-4.388368,
     "geom:longitude":13.841062,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CG.BO.MF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897043,
-    "wof:geomhash":"fce8db4da775b50165236dbb12387ece",
+    "wof:geomhash":"219d36fb88f0514eb3e8d16d11d10706",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1092012477,
-    "wof:lastmodified":1627521989,
+    "wof:lastmodified":1695886461,
     "wof:name":"Mfouati",
     "wof:parent_id":85670027,
     "wof:placetype":"county",

--- a/data/109/201/251/9/1092012519.geojson
+++ b/data/109/201/251/9/1092012519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.422455,
-    "geom:area_square_m":5211667847.006909,
+    "geom:area_square_m":5211667847.006989,
     "geom:bbox":"13.5149594008,-4.32391199269,14.3764271766,-3.45051792767",
     "geom:latitude":-3.890233,
     "geom:longitude":13.95335,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"CG.BO.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897044,
-    "wof:geomhash":"f06c962c65f8e52cf85aa6dbc5302948",
+    "wof:geomhash":"b5d50e5e4d73c400c04ff9e6e9e873e3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1092012519,
-    "wof:lastmodified":1566638966,
+    "wof:lastmodified":1695886315,
     "wof:name":"Mouyondzi",
     "wof:parent_id":85670027,
     "wof:placetype":"county",

--- a/data/109/201/254/9/1092012549.geojson
+++ b/data/109/201/254/9/1092012549.geojson
@@ -423,6 +423,7 @@
     "wof:concordances":{
         "hasc:id":"CG.BR.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897046,
     "wof:geomhash":"8c26a1216a63b2ffa1fe0ee1ef121db2",
@@ -435,7 +436,7 @@
         }
     ],
     "wof:id":1092012549,
-    "wof:lastmodified":1694497839,
+    "wof:lastmodified":1695886316,
     "wof:name":"Brazzaville",
     "wof:parent_id":85670067,
     "wof:placetype":"county",

--- a/data/109/201/259/1/1092012591.geojson
+++ b/data/109/201/259/1/1092012591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.463071,
-    "geom:area_square_m":5725430456.262282,
+    "geom:area_square_m":5725430501.494494,
     "geom:bbox":"14.421162,-1.191253,15.184831,-0.217232",
     "geom:latitude":-0.74545,
     "geom:longitude":14.818676,
@@ -143,9 +143,10 @@
     "wof:concordances":{
         "hasc:id":"CG.CO.EW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897047,
-    "wof:geomhash":"f99135593f6846c0db4416ebe05317b9",
+    "wof:geomhash":"9fb3b6eb4fe199aa5dc0f64eba3e3e96",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1092012591,
-    "wof:lastmodified":1636501770,
+    "wof:lastmodified":1695886796,
     "wof:name":"Ewo",
     "wof:parent_id":85670023,
     "wof:placetype":"county",

--- a/data/109/201/263/1/1092012631.geojson
+++ b/data/109/201/263/1/1092012631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.602038,
-    "geom:area_square_m":7444248022.711019,
+    "geom:area_square_m":7444248022.711087,
     "geom:bbox":"13.818179833,-0.61654770727,14.9411996951,0.464460290825",
     "geom:latitude":-0.109465,
     "geom:longitude":14.36637,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"CG.CO.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897049,
-    "wof:geomhash":"85386a4805dea88adac694f15d19cac7",
+    "wof:geomhash":"293023d5872af0db8dbc24f6648ea43a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092012631,
-    "wof:lastmodified":1566638971,
+    "wof:lastmodified":1695886316,
     "wof:name":"K\u00e9ll\u00e9",
     "wof:parent_id":85670023,
     "wof:placetype":"county",

--- a/data/109/201/267/3/1092012673.geojson
+++ b/data/109/201/267/3/1092012673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.938621,
-    "geom:area_square_m":11605396897.434502,
+    "geom:area_square_m":11605396941.616341,
     "geom:bbox":"14.060464,0.033169,15.27296,1.392461",
     "geom:latitude":0.598498,
     "geom:longitude":14.705218,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CG.CO.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897050,
-    "wof:geomhash":"090e7eedfc68acf59fb30ad3dd715b0a",
+    "wof:geomhash":"a136aee6600a94562a02f8f4af8811f8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1092012673,
-    "wof:lastmodified":1627521989,
+    "wof:lastmodified":1695886461,
     "wof:name":"Mbomo",
     "wof:parent_id":85670023,
     "wof:placetype":"county",

--- a/data/109/201/271/5/1092012715.geojson
+++ b/data/109/201/271/5/1092012715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.255053,
-    "geom:area_square_m":3153468707.203367,
+    "geom:area_square_m":3153468707.203565,
     "geom:bbox":"15.0088717169,-1.19801171562,15.6496954432,-0.410413107538",
     "geom:latitude":-0.787131,
     "geom:longitude":15.296107,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"CG.CU.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897052,
-    "wof:geomhash":"df22866f12c7ab42164718deeb17a0a9",
+    "wof:geomhash":"4db6b8b9b9acd89bc33ea2e0f8c27f6d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1092012715,
-    "wof:lastmodified":1566638970,
+    "wof:lastmodified":1695886316,
     "wof:name":"Boundji",
     "wof:parent_id":85670045,
     "wof:placetype":"county",

--- a/data/109/201/275/7/1092012757.geojson
+++ b/data/109/201/275/7/1092012757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.441382,
-    "geom:area_square_m":5457540154.701174,
+    "geom:area_square_m":5457540154.701161,
     "geom:bbox":"16.7416384143,-1.09787121042,17.4831423752,0.396113081037",
     "geom:latitude":-0.328193,
     "geom:longitude":17.069495,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"CG.CU.LO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897054,
-    "wof:geomhash":"e4c53dbfdc63dd218db89b13e3e77d80",
+    "wof:geomhash":"84474891b648bdc78105e7f420ee87d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092012757,
-    "wof:lastmodified":1566638964,
+    "wof:lastmodified":1695886314,
     "wof:name":"Loukol\u00e9la",
     "wof:parent_id":85670045,
     "wof:placetype":"county",

--- a/data/109/201/279/9/1092012799.geojson
+++ b/data/109/201/279/9/1092012799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.691825,
-    "geom:area_square_m":8554510558.202442,
+    "geom:area_square_m":8554510281.708584,
     "geom:bbox":"14.887058,-0.271918,16.361864,0.467351",
     "geom:latitude":0.060379,
     "geom:longitude":15.617776,
@@ -128,9 +128,10 @@
     "wof:concordances":{
         "hasc:id":"CG.CU.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897055,
-    "wof:geomhash":"10a4c058483287b4fd90fdccc7f88d52",
+    "wof:geomhash":"32c82bf9b522a7b903538d5bd09aea78",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092012799,
-    "wof:lastmodified":1636501771,
+    "wof:lastmodified":1695886796,
     "wof:name":"Makoua",
     "wof:parent_id":85670045,
     "wof:placetype":"county",

--- a/data/109/201/280/7/1092012807.geojson
+++ b/data/109/201/280/7/1092012807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.957254,
-    "geom:area_square_m":11835328818.49424,
+    "geom:area_square_m":11835329135.987328,
     "geom:bbox":"16.152814,-1.594799,17.056852,0.241195",
     "geom:latitude":-0.71268,
     "geom:longitude":16.625842,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CG.CU.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897057,
-    "wof:geomhash":"0039b851da2f9af12950fbd722297220",
+    "wof:geomhash":"bf347be9bcb273b7a4a1568465fa777a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1092012807,
-    "wof:lastmodified":1627521990,
+    "wof:lastmodified":1695886463,
     "wof:name":"Mossaka",
     "wof:parent_id":85670045,
     "wof:placetype":"county",

--- a/data/109/201/280/9/1092012809.geojson
+++ b/data/109/201/280/9/1092012809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.400991,
-    "geom:area_square_m":4956697596.590649,
+    "geom:area_square_m":4956697596.591007,
     "geom:bbox":"14.3706308237,-2.02645040844,15.2030996758,-1.05330621382",
     "geom:latitude":-1.45578,
     "geom:longitude":14.743422,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"CG.CO.OK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897058,
-    "wof:geomhash":"119d8b4108222bf6e3f70d7b5f9fee62",
+    "wof:geomhash":"79a26c3f7d10af92341379e6936e10b3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1092012809,
-    "wof:lastmodified":1566638963,
+    "wof:lastmodified":1695886314,
     "wof:name":"Okoyo",
     "wof:parent_id":85670023,
     "wof:placetype":"county",

--- a/data/109/201/285/3/1092012853.geojson
+++ b/data/109/201/285/3/1092012853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.865409,
-    "geom:area_square_m":10700230494.859531,
+    "geom:area_square_m":10700230857.467335,
     "geom:bbox":"15.089401,-1.257214,16.512593,-0.058497",
     "geom:latitude":-0.613011,
     "geom:longitude":15.907622,
@@ -137,9 +137,10 @@
     "wof:concordances":{
         "hasc:id":"CG.CU.OW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897060,
-    "wof:geomhash":"e423bc576bd7b470db9fb1ef44f5ce38",
+    "wof:geomhash":"82dd734ce2258405cc74ac82f8281d8f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1092012853,
-    "wof:lastmodified":1636501771,
+    "wof:lastmodified":1695886796,
     "wof:name":"Owando",
     "wof:parent_id":85670045,
     "wof:placetype":"county",

--- a/data/109/201/287/5/1092012875.geojson
+++ b/data/109/201/287/5/1092012875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.238696,
-    "geom:area_square_m":2944181329.01449,
+    "geom:area_square_m":2944182087.509246,
     "geom:bbox":"11.618303,-4.38,12.221769,-3.665969",
     "geom:latitude":-4.038589,
     "geom:longitude":11.94202,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CG.KL.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897062,
-    "wof:geomhash":"b27bcd370fcf88b8f29100ebad9aeebb",
+    "wof:geomhash":"4bbd824daeb7f988043ef45258d12802",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1092012875,
-    "wof:lastmodified":1627521988,
+    "wof:lastmodified":1695886459,
     "wof:name":"Kakamoeka",
     "wof:parent_id":85670049,
     "wof:placetype":"county",

--- a/data/109/201/292/3/1092012923.geojson
+++ b/data/109/201/292/3/1092012923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.343653,
-    "geom:area_square_m":4239102821.047575,
+    "geom:area_square_m":4239102821.047551,
     "geom:bbox":"11.1532420114,-4.42260631968,11.903251707,-3.493891",
     "geom:latitude":-3.97057,
     "geom:longitude":11.524021,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"CG.KL.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897063,
-    "wof:geomhash":"1e6b31473965475c97bbe27bbd943029",
+    "wof:geomhash":"f7c4539a38ee6a82da295501c7044aca",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1092012923,
-    "wof:lastmodified":1566638964,
+    "wof:lastmodified":1695886314,
     "wof:name":"Madingo-Kayes",
     "wof:parent_id":85670049,
     "wof:placetype":"county",

--- a/data/109/201/297/7/1092012977.geojson
+++ b/data/109/201/297/7/1092012977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.25987,
-    "geom:area_square_m":3210313826.131715,
+    "geom:area_square_m":3210313826.13167,
     "geom:bbox":"13.0272407601,-2.79343109245,13.9633501195,-2.088873",
     "geom:latitude":-2.483397,
     "geom:longitude":13.582399,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CG.LE.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897065,
-    "wof:geomhash":"1f0af6ec103f7b15c43d00346dbd4628",
+    "wof:geomhash":"7c061f9e3e31a22d5ea017fba60d6a1c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1092012977,
-    "wof:lastmodified":1566638970,
+    "wof:lastmodified":1695886316,
     "wof:name":"Bambama",
     "wof:parent_id":85670053,
     "wof:placetype":"county",

--- a/data/109/201/302/1/1092013021.geojson
+++ b/data/109/201/302/1/1092013021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.376992,
-    "geom:area_square_m":4655522118.514517,
+    "geom:area_square_m":4655522095.939707,
     "geom:bbox":"12.994085,-3.34153,13.673617,-2.398457",
     "geom:latitude":-2.915229,
     "geom:longitude":13.314871,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CG.LE.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897067,
-    "wof:geomhash":"9e04fb2e84f6977e6d21243e6256958b",
+    "wof:geomhash":"bf302dd8b8ca27ab73a11546e3ddbfdf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1092013021,
-    "wof:lastmodified":1627521989,
+    "wof:lastmodified":1695886461,
     "wof:name":"Komono",
     "wof:parent_id":85670053,
     "wof:placetype":"county",

--- a/data/109/201/306/7/1092013067.geojson
+++ b/data/109/201/306/7/1092013067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.588505,
-    "geom:area_square_m":7262649553.347739,
+    "geom:area_square_m":7262649600.562819,
     "geom:bbox":"12.599731,-4.056546,13.868967,-3.212784",
     "geom:latitude":-3.5916,
     "geom:longitude":13.239447,
@@ -128,9 +128,10 @@
     "wof:concordances":{
         "hasc:id":"CG.LE.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897069,
-    "wof:geomhash":"9d054cd53931dbfaeaabf82952aaf9e7",
+    "wof:geomhash":"fd7c82f95c393434d411912c9d923c97",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092013067,
-    "wof:lastmodified":1636501769,
+    "wof:lastmodified":1695886796,
     "wof:name":"Sibiti",
     "wof:parent_id":85670053,
     "wof:placetype":"county",

--- a/data/109/201/310/9/1092013109.geojson
+++ b/data/109/201/310/9/1092013109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.479948,
-    "geom:area_square_m":5926498846.050299,
+    "geom:area_square_m":5926498846.050485,
     "geom:bbox":"13.4273597316,-3.5328600679,14.3454554372,-2.464114",
     "geom:latitude":-2.993512,
     "geom:longitude":13.911013,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"CG.LE.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897070,
-    "wof:geomhash":"a17c499fd392248108f611f24b282548",
+    "wof:geomhash":"6038e9bfd09d62f9b1f3f7d3f0d56c24",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092013109,
-    "wof:lastmodified":1566638973,
+    "wof:lastmodified":1695886317,
     "wof:name":"Zanaga",
     "wof:parent_id":85670053,
     "wof:placetype":"county",

--- a/data/109/201/314/9/1092013149.geojson
+++ b/data/109/201/314/9/1092013149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.506624,
-    "geom:area_square_m":30953111281.666878,
+    "geom:area_square_m":30953111281.666355,
     "geom:bbox":"16.4514445085,1.89421426213,18.643611,3.707791",
     "geom:latitude":2.949545,
     "geom:longitude":17.55819,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"CG.LI.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897072,
-    "wof:geomhash":"8e997818993ec95ce92a02d66d5847ba",
+    "wof:geomhash":"2877592e883684dace7447729deb516d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1092013149,
-    "wof:lastmodified":1566638967,
+    "wof:lastmodified":1695886315,
     "wof:name":"Dongou",
     "wof:parent_id":85670031,
     "wof:placetype":"county",

--- a/data/109/201/319/3/1092013193.geojson
+++ b/data/109/201/319/3/1092013193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.343624,
-    "geom:area_square_m":28971104311.301083,
+    "geom:area_square_m":28971103240.623474,
     "geom:bbox":"16.679571,-0.793756,17.782153,2.5",
     "geom:latitude":1.096664,
     "geom:longitude":17.254768,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"CG.LI.EP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897073,
-    "wof:geomhash":"c6423aa45009cc86ac8ce7f392e0b9e5",
+    "wof:geomhash":"24f5c9a8df88bb559de974be06124a1d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092013193,
-    "wof:lastmodified":1627521988,
+    "wof:lastmodified":1695886460,
     "wof:name":"Ep\u00e9na",
     "wof:parent_id":85670031,
     "wof:placetype":"county",

--- a/data/109/201/323/9/1092013239.geojson
+++ b/data/109/201/323/9/1092013239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.578471,
-    "geom:area_square_m":7151479787.547089,
+    "geom:area_square_m":7151481001.074135,
     "geom:bbox":"17.56,-0.695171,18.079167,2.063848",
     "geom:latitude":0.893208,
     "geom:longitude":17.808968,
@@ -140,9 +140,10 @@
     "wof:concordances":{
         "hasc:id":"CG.LI.IM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897075,
-    "wof:geomhash":"bc18096f4359dbdd55dc5dad5dfeb218",
+    "wof:geomhash":"bc9333486d21d087dc1ec891fe8feddc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1092013239,
-    "wof:lastmodified":1636501770,
+    "wof:lastmodified":1695886796,
     "wof:name":"Impfondo",
     "wof:parent_id":85670031,
     "wof:placetype":"county",

--- a/data/109/201/327/1/1092013271.geojson
+++ b/data/109/201/327/1/1092013271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.463141,
-    "geom:area_square_m":5720521847.425233,
+    "geom:area_square_m":5720521847.425439,
     "geom:bbox":"11.518748,-3.06152675933,12.5212944833,-2.337718",
     "geom:latitude":-2.684124,
     "geom:longitude":11.99171,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"CG.NI.DI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897076,
-    "wof:geomhash":"049e70e47b126114dad4edb12af58c60",
+    "wof:geomhash":"bdabb6d4e6529b2f2e5cb53db244de14",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092013271,
-    "wof:lastmodified":1566638972,
+    "wof:lastmodified":1695886317,
     "wof:name":"Div\u00e9ni\u00e9",
     "wof:parent_id":85670059,
     "wof:placetype":"county",

--- a/data/109/201/331/9/1092013319.geojson
+++ b/data/109/201/331/9/1092013319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.421786,
-    "geom:area_square_m":5206327656.020089,
+    "geom:area_square_m":5206327656.020078,
     "geom:bbox":"11.661776,-3.89411606086,12.5222362031,-2.87040918812",
     "geom:latitude":-3.384355,
     "geom:longitude":12.109377,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"CG.NI.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897078,
-    "wof:geomhash":"db8c8786dd20c20b57f7309f22b064aa",
+    "wof:geomhash":"388a3e349208ecbe0b148b9e9218ab42",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092013319,
-    "wof:lastmodified":1566638961,
+    "wof:lastmodified":1695886312,
     "wof:name":"Kibangou",
     "wof:parent_id":85670059,
     "wof:placetype":"county",

--- a/data/109/201/336/3/1092013363.geojson
+++ b/data/109/201/336/3/1092013363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.165481,
-    "geom:area_square_m":2039722488.862592,
+    "geom:area_square_m":2039722997.282427,
     "geom:bbox":"12.771647,-4.916207,13.58,-4.317238",
     "geom:latitude":-4.560995,
     "geom:longitude":13.179783,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CG.NI.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897079,
-    "wof:geomhash":"ffe56886c68b4baabb5c8259557057ae",
+    "wof:geomhash":"b260728de2a665f17c567330a0a9a7e3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1092013363,
-    "wof:lastmodified":1627521988,
+    "wof:lastmodified":1695886460,
     "wof:name":"Kimongo",
     "wof:parent_id":85670059,
     "wof:placetype":"county",

--- a/data/109/201/340/1/1092013401.geojson
+++ b/data/109/201/340/1/1092013401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.359901,
-    "geom:area_square_m":4446711976.71024,
+    "geom:area_square_m":4446712576.170359,
     "geom:bbox":"12.442157,-2.68,13.046833,-1.812376",
     "geom:latitude":-2.273232,
     "geom:longitude":12.734749,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CG.NI.MY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897081,
-    "wof:geomhash":"2236fb2247b20227d4e88bdd59be44f3",
+    "wof:geomhash":"62e0a2417d880f4169d8bb4cebe9322d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1092013401,
-    "wof:lastmodified":1627521989,
+    "wof:lastmodified":1695886461,
     "wof:name":"Mayoko",
     "wof:parent_id":85670059,
     "wof:placetype":"county",

--- a/data/109/201/345/1/1092013451.geojson
+++ b/data/109/201/345/1/1092013451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.535496,
-    "geom:area_square_m":6612364414.938438,
+    "geom:area_square_m":6612364684.779228,
     "geom:bbox":"12.264996,-3.52635,13.132908,-2.559498",
     "geom:latitude":-3.004032,
     "geom:longitude":12.675767,
@@ -131,9 +131,10 @@
     "wof:concordances":{
         "hasc:id":"CG.NI.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897082,
-    "wof:geomhash":"da8ad8b6fcfe776bbf6e6e7d0c5acaf8",
+    "wof:geomhash":"5d09266a505f02074f5772f25cbed585",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1092013451,
-    "wof:lastmodified":1636501771,
+    "wof:lastmodified":1695886796,
     "wof:name":"Mossendjo",
     "wof:parent_id":85670059,
     "wof:placetype":"county",

--- a/data/109/201/348/9/1092013489.geojson
+++ b/data/109/201/348/9/1092013489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.695994,
-    "geom:area_square_m":8603361109.698374,
+    "geom:area_square_m":8603361109.698286,
     "geom:bbox":"14.9398731083,-1.99661389642,16.350250901,-0.936762446472",
     "geom:latitude":-1.426817,
     "geom:longitude":15.547236,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"CG.PL.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897084,
-    "wof:geomhash":"6d70394d017b866a772ba7585a0a9d61",
+    "wof:geomhash":"7a7b69a5a78d2bfacbedd80e4f38a561",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092013489,
-    "wof:lastmodified":1566638966,
+    "wof:lastmodified":1695886315,
     "wof:name":"Abala",
     "wof:parent_id":85670063,
     "wof:placetype":"county",

--- a/data/109/201/352/9/1092013529.geojson
+++ b/data/109/201/352/9/1092013529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.371682,
-    "geom:area_square_m":16944852786.16073,
+    "geom:area_square_m":16944853190.916,
     "geom:bbox":"14.259702,-3.085043,16.23236,-1.581144",
     "geom:latitude":-2.487172,
     "geom:longitude":15.20072,
@@ -149,9 +149,10 @@
     "wof:concordances":{
         "hasc:id":"CG.PL.DJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897085,
-    "wof:geomhash":"a80c9258f0370ab0edcbcc11c59cd17a",
+    "wof:geomhash":"d4db08950795ce6016d3d147cd54dfa0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":1092013529,
-    "wof:lastmodified":1636501770,
+    "wof:lastmodified":1695886796,
     "wof:name":"Djambala",
     "wof:parent_id":85670063,
     "wof:placetype":"county",

--- a/data/109/201/357/1/1092013571.geojson
+++ b/data/109/201/357/1/1092013571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.811803,
-    "geom:area_square_m":10032327560.384211,
+    "geom:area_square_m":10032326831.971834,
     "geom:bbox":"15.311651,-2.572662,16.656969,-1.453301",
     "geom:latitude":-1.92605,
     "geom:longitude":15.983209,
@@ -125,9 +125,10 @@
     "wof:concordances":{
         "hasc:id":"CG.PL.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897087,
-    "wof:geomhash":"85558dbd40ad3cc715d970b72227b8ad",
+    "wof:geomhash":"67d8dbedcc1e23cd68fcae062c559de0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1092013571,
-    "wof:lastmodified":1636501771,
+    "wof:lastmodified":1695886796,
     "wof:name":"Gamboma",
     "wof:parent_id":85670063,
     "wof:placetype":"county",

--- a/data/109/201/360/9/1092013609.geojson
+++ b/data/109/201/360/9/1092013609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.346097,
-    "geom:area_square_m":4276068266.827089,
+    "geom:area_square_m":4276068065.304542,
     "geom:bbox":"14.116034,-2.787036,14.825428,-1.875186",
     "geom:latitude":-2.305179,
     "geom:longitude":14.441547,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"CG.PL.LE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897089,
-    "wof:geomhash":"14f3ea2d2ef1a3738a204ecf98576ab5",
+    "wof:geomhash":"e7daf5b49788f83d1035733f7cfdb279",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092013609,
-    "wof:lastmodified":1627521989,
+    "wof:lastmodified":1695886462,
     "wof:name":"L\u00e9kana",
     "wof:parent_id":85670063,
     "wof:placetype":"county",

--- a/data/109/201/364/9/1092013649.geojson
+++ b/data/109/201/364/9/1092013649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003943,
-    "geom:area_square_m":48583610.631316,
+    "geom:area_square_m":48583502.719052,
     "geom:bbox":"11.821222,-4.830029,11.912168,-4.744209",
     "geom:latitude":-4.787165,
     "geom:longitude":11.871086,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"CG.KL.TN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897090,
-    "wof:geomhash":"46f7a0260c33503707bd4379403ad1cc",
+    "wof:geomhash":"81de82105e5f89965d9402c6c85a03ca",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092013649,
-    "wof:lastmodified":1627521990,
+    "wof:lastmodified":1695886463,
     "wof:name":"Tchamba Nzassi",
     "wof:parent_id":85670071,
     "wof:placetype":"county",

--- a/data/109/201/368/5/1092013685.geojson
+++ b/data/109/201/368/5/1092013685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.224152,
-    "geom:area_square_m":2762608425.072658,
+    "geom:area_square_m":2762608425.072745,
     "geom:bbox":"14.351067,-4.922633,14.9626056885,-4.29882183849",
     "geom:latitude":-4.637083,
     "geom:longitude":14.637179,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"CG.PO.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897092,
-    "wof:geomhash":"a0280c71318a4ebbfe78f62367ba06e3",
+    "wof:geomhash":"7f8c49d2456c3ac61321d46776ffad90",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1092013685,
-    "wof:lastmodified":1566638967,
+    "wof:lastmodified":1695886316,
     "wof:name":"Boko",
     "wof:parent_id":85670041,
     "wof:placetype":"county",

--- a/data/109/201/372/9/1092013729.geojson
+++ b/data/109/201/372/9/1092013729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.589242,
-    "geom:area_square_m":7272768747.327156,
+    "geom:area_square_m":7272768747.327053,
     "geom:bbox":"13.8680260238,-4.01980240598,14.8745416606,-2.71970206748",
     "geom:latitude":-3.453484,
     "geom:longitude":14.44815,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"CG.PO.KD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897094,
-    "wof:geomhash":"fb7bdfb5935ca652e59d1289d481abef",
+    "wof:geomhash":"48cadf46fb4ae113d316bb3665c986d2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1092013729,
-    "wof:lastmodified":1566638973,
+    "wof:lastmodified":1695886317,
     "wof:name":"Kindamba",
     "wof:parent_id":85670041,
     "wof:placetype":"county",

--- a/data/109/201/376/5/1092013765.geojson
+++ b/data/109/201/376/5/1092013765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164084,
-    "geom:area_square_m":2023238609.448315,
+    "geom:area_square_m":2023238508.71891,
     "geom:bbox":"14.62,-4.627665,15.076951,-4.024741",
     "geom:latitude":-4.289602,
     "geom:longitude":14.852205,
@@ -128,9 +128,10 @@
     "wof:concordances":{
         "hasc:id":"CG.PO.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897095,
-    "wof:geomhash":"eb7ed83fed86d89d8f3ac8cbc6d3c709",
+    "wof:geomhash":"650954e45c4feabb7da16757a67a1aae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092013765,
-    "wof:lastmodified":1636501770,
+    "wof:lastmodified":1695886796,
     "wof:name":"Kinkala",
     "wof:parent_id":85670041,
     "wof:placetype":"county",

--- a/data/109/201/378/7/1092013787.geojson
+++ b/data/109/201/378/7/1092013787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.604664,
-    "geom:area_square_m":7463526861.069485,
+    "geom:area_square_m":7463526770.066079,
     "geom:bbox":"14.650245,-4.23235,15.515958,-2.714159",
     "geom:latitude":-3.398454,
     "geom:longitude":15.016202,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"CG.PO.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897097,
-    "wof:geomhash":"49cb18fe62492c42c775fd78bd249f6c",
+    "wof:geomhash":"eea097052ab9f7f2f30561657db61119",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1092013787,
-    "wof:lastmodified":1627521989,
+    "wof:lastmodified":1695886462,
     "wof:name":"Mayama",
     "wof:parent_id":85670041,
     "wof:placetype":"county",

--- a/data/109/201/382/7/1092013827.geojson
+++ b/data/109/201/382/7/1092013827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.237166,
-    "geom:area_square_m":2924733817.701877,
+    "geom:area_square_m":2924733817.701825,
     "geom:bbox":"13.9033039398,-4.517794,14.9178407762,-3.95069752044",
     "geom:latitude":-4.19529,
     "geom:longitude":14.355916,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"CG.PO.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897098,
-    "wof:geomhash":"cb3fcd330ed5eb80a747f995ded9242a",
+    "wof:geomhash":"2b0d39cf0fa3e13cc118fd82ca950a53",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092013827,
-    "wof:lastmodified":1566638966,
+    "wof:lastmodified":1695886315,
     "wof:name":"Mindouli",
     "wof:parent_id":85670041,
     "wof:placetype":"county",

--- a/data/109/201/386/7/1092013867.geojson
+++ b/data/109/201/386/7/1092013867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.557679,
-    "geom:area_square_m":6884474244.748671,
+    "geom:area_square_m":6884474545.328191,
     "geom:bbox":"15.25352,-3.811181,16.215223,-2.82046",
     "geom:latitude":-3.279012,
     "geom:longitude":15.786522,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"CG.PO.NG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897099,
-    "wof:geomhash":"32ab2dc5b842bc38dcf9118f5ae38a80",
+    "wof:geomhash":"40ad290091a91f3ecd635bd0d5227eb8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092013867,
-    "wof:lastmodified":1627521990,
+    "wof:lastmodified":1695886463,
     "wof:name":"Ngab\u00e9",
     "wof:parent_id":85670041,
     "wof:placetype":"county",

--- a/data/109/201/389/9/1092013899.geojson
+++ b/data/109/201/389/9/1092013899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.457618,
-    "geom:area_square_m":5645296154.406003,
+    "geom:area_square_m":5645296855.484114,
     "geom:bbox":"14.975705,-4.507331,15.951181,-3.452305",
     "geom:latitude":-3.914388,
     "geom:longitude":15.427676,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"CG.PO.GT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897101,
-    "wof:geomhash":"ef6807bc24c75fe8384ebc4222783dcc",
+    "wof:geomhash":"2e68f83c51677279b318b26253ee59a2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092013899,
-    "wof:lastmodified":1627521988,
+    "wof:lastmodified":1695886460,
     "wof:name":"Goma Ts\u00e9-Ts\u00e9\t",
     "wof:parent_id":85670041,
     "wof:placetype":"county",

--- a/data/109/201/394/3/1092013943.geojson
+++ b/data/109/201/394/3/1092013943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.060594,
-    "geom:area_square_m":37834880145.210617,
+    "geom:area_square_m":37834879884.210396,
     "geom:bbox":"14.506376,0.0386,17.047082,2.721711",
     "geom:latitude":1.183884,
     "geom:longitude":16.006232,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CG.SA.OU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897103,
-    "wof:geomhash":"b22e5880b17a225186ee8879b7dd2f4b",
+    "wof:geomhash":"29d1270b7cd015611c36d5f674a328a6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1092013943,
-    "wof:lastmodified":1627521990,
+    "wof:lastmodified":1695886463,
     "wof:name":"Ouesso",
     "wof:parent_id":85670035,
     "wof:placetype":"county",

--- a/data/109/201/399/1/1092013991.geojson
+++ b/data/109/201/399/1/1092013991.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.711511,
-    "geom:area_square_m":8793928611.464186,
+    "geom:area_square_m":8793928611.463917,
     "geom:bbox":"14.1037957969,1.3576115,15.6365251142,2.207125",
     "geom:latitude":1.726452,
     "geom:longitude":14.825974,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"CG.SA.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897104,
-    "wof:geomhash":"2f157402abe8cb6dc43822824731d40a",
+    "wof:geomhash":"361075a72bf3840ad2f937ac26e50dc8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1092013991,
-    "wof:lastmodified":1566638961,
+    "wof:lastmodified":1695886313,
     "wof:name":"Semb\u00e9",
     "wof:parent_id":85670035,
     "wof:placetype":"county",

--- a/data/109/201/399/3/1092013993.geojson
+++ b/data/109/201/399/3/1092013993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.923288,
-    "geom:area_square_m":11411106559.216761,
+    "geom:area_square_m":11411106559.216717,
     "geom:bbox":"13.125131,1.216018,14.4375673939,2.1924475",
     "geom:latitude":1.76783,
     "geom:longitude":13.743903,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"CG.SA.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897106,
-    "wof:geomhash":"a17f651761d498309006b1e726366321",
+    "wof:geomhash":"629eed4e00972c07a9119848a67fa639",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092013993,
-    "wof:lastmodified":1566638962,
+    "wof:lastmodified":1695886313,
     "wof:name":"Souank\u00e9",
     "wof:parent_id":85670035,
     "wof:placetype":"county",

--- a/data/109/201/399/5/1092013995.geojson
+++ b/data/109/201/399/5/1092013995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.29906,
-    "geom:area_square_m":3687188537.019531,
+    "geom:area_square_m":3687188537.019341,
     "geom:bbox":"12.077511221,-4.814291,12.782306,-3.89459308884",
     "geom:latitude":-4.364587,
     "geom:longitude":12.381627,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CG.KL.MV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1473897107,
-    "wof:geomhash":"49641ba68ba72adc4cb8a31e05d9264d",
+    "wof:geomhash":"553e0cdb58d0897fe3b8d906da52ef0d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1092013995,
-    "wof:lastmodified":1566638963,
+    "wof:lastmodified":1695886314,
     "wof:name":"Mvouti",
     "wof:parent_id":85670049,
     "wof:placetype":"county",

--- a/data/421/171/019/421171019.geojson
+++ b/data/421/171/019/421171019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.225136,
-    "geom:area_square_m":2774751713.572645,
+    "geom:area_square_m":2774751566.26164,
     "geom:bbox":"11.640394,-5.031389,12.240897,-4.339653",
     "geom:latitude":-4.631843,
     "geom:longitude":11.983795,
@@ -97,12 +97,13 @@
         "wd:id":"Q7208306",
         "wk:page":"Pointe-Noire District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1459008879,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e76c84a2494780d77f68ffd50482dc2d",
+    "wof:geomhash":"cbb122d3cadd20ec4fc8ea7661470411",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":421171019,
-    "wof:lastmodified":1627521989,
+    "wof:lastmodified":1695886461,
     "wof:name":"Loandjili",
     "wof:parent_id":85670049,
     "wof:placetype":"county",

--- a/data/421/184/609/421184609.geojson
+++ b/data/421/184/609/421184609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096121,
-    "geom:area_square_m":1185338369.437574,
+    "geom:area_square_m":1185338212.427091,
     "geom:bbox":"13.13416,-4.41538,13.480692,-3.976066",
     "geom:latitude":-4.211446,
     "geom:longitude":13.300791,
@@ -91,12 +91,13 @@
         "hasc:id":"CG.BO.NK",
         "qs_pg:id":1002250
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1459009416,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0409f1e6a5313a8e2d7068b301691388",
+    "wof:geomhash":"027fdbf752da331a9728b6dae55ade5f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421184609,
-    "wof:lastmodified":1627521990,
+    "wof:lastmodified":1695886462,
     "wof:name":"Nkayi District",
     "wof:parent_id":85670027,
     "wof:placetype":"county",

--- a/data/421/204/287/421204287.geojson
+++ b/data/421/204/287/421204287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.304261,
-    "geom:area_square_m":3753279673.476586,
+    "geom:area_square_m":3753278995.1913,
     "geom:bbox":"12.170998,-4.392677,12.995689,-3.482433",
     "geom:latitude":-3.950331,
     "geom:longitude":12.56797,
@@ -106,12 +106,13 @@
         "wd:id":"Q3264057",
         "wk:page":"Louvakou District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CG",
     "wof:created":1459010179,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c21e938ef5745b49e8412c0e04608201",
+    "wof:geomhash":"57f448365cfdca5a3cfce80eb530546e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":421204287,
-    "wof:lastmodified":1690865904,
+    "wof:lastmodified":1695886795,
     "wof:name":"Louvakou (Loubomo)",
     "wof:parent_id":85670059,
     "wof:placetype":"county",

--- a/data/856/325/41/85632541.geojson
+++ b/data/856/325/41/85632541.geojson
@@ -1353,6 +1353,7 @@
         "hasc:id":"CG",
         "icao:code":"9Q",
         "ioc:id":"CGO",
+        "iso:code":"CG",
         "itu:id":"COG",
         "m49:code":"178",
         "marc:id":"cf",
@@ -1366,6 +1367,7 @@
         "wk:page":"Republic of the Congo",
         "wmo:id":"CG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CG",
     "wof:country_alpha3":"COG",
     "wof:geom_alt":[
@@ -1387,7 +1389,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694639542,
+    "wof:lastmodified":1695881199,
     "wof:name":"Republic of Congo",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/700/23/85670023.geojson
+++ b/data/856/700/23/85670023.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.404721,
-    "geom:area_square_m":29731772973.000683,
+    "geom:area_square_m":29731770612.051571,
     "geom:bbox":"13.81818,-2.02645,15.27296,1.392461",
     "geom:latitude":-0.1801,
     "geom:longitude":14.648604,
@@ -295,17 +295,19 @@
         "gn:id":2593118,
         "gp:id":55998384,
         "hasc:id":"CG.CO",
+        "iso:code":"CG-15",
         "iso:id":"CG-15",
         "qs_pg:id":1024056,
         "unlc:id":"CG-15",
         "wd:id":"Q125711",
         "wk:page":"Cuvette-Ouest Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8d655b731c6dc4a686abb3b90f476fcd",
+    "wof:geomhash":"ba9c0e598fdd4ade2e4ca59ed8e96720",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -320,7 +322,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690865898,
+    "wof:lastmodified":1695884905,
     "wof:name":"Cuvette-Ouest",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/27/85670027.geojson
+++ b/data/856/700/27/85670027.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.016929,
-    "geom:area_square_m":12542736293.488617,
+    "geom:area_square_m":12542735909.943981,
     "geom:bbox":"12.594348,-4.805362,14.376427,-3.450518",
     "geom:latitude":-4.065638,
     "geom:longitude":13.560758,
@@ -300,17 +300,19 @@
         "gn:id":2260668,
         "gp:id":2344967,
         "hasc:id":"CG.BO",
+        "iso:code":"CG-11",
         "iso:id":"CG-11",
         "qs_pg:id":1134969,
         "unlc:id":"CG-11",
         "wd:id":"Q827015",
         "wk:page":"Bouenza Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"61e290f93c3bb4940a02c9b38ff2ddab",
+    "wof:geomhash":"371d97e142287108b208ea9b952c0c2d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -325,7 +327,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690865896,
+    "wof:lastmodified":1695884904,
     "wof:name":"Bouenza",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/31/85670031.geojson
+++ b/data/856/700/31/85670031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.428719,
-    "geom:area_square_m":67075695380.515083,
+    "geom:area_square_m":67075695555.038292,
     "geom:bbox":"16.451445,-0.793756,18.643611,3.707791",
     "geom:latitude":1.930522,
     "geom:longitude":17.453923,
@@ -302,16 +302,18 @@
         "gn:id":2258431,
         "gp:id":2344971,
         "hasc:id":"CG.LI",
+        "iso:code":"CG-7",
         "iso:id":"CG-7",
         "qs_pg:id":672355,
         "unlc:id":"CG-7",
         "wd:id":"Q863554"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"47b39626288b293f8bb8bfbe32cda258",
+    "wof:geomhash":"581824c2a453f1c2ed873294332cfb09",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690865896,
+    "wof:lastmodified":1695884904,
     "wof:name":"Likouala",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/35/85670035.geojson
+++ b/data/856/700/35/85670035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.695393,
-    "geom:area_square_m":58039915315.890869,
+    "geom:area_square_m":58039914803.592636,
     "geom:bbox":"13.125131,0.0386,17.047082,2.721711",
     "geom:latitude":1.380927,
     "geom:longitude":15.382525,
@@ -295,17 +295,19 @@
         "gn:id":2255329,
         "gp:id":2344974,
         "hasc:id":"CG.SA",
+        "iso:code":"CG-13",
         "iso:id":"CG-13",
         "qs_pg:id":894868,
         "unlc:id":"CG-13",
         "wd:id":"Q775410",
         "wk:page":"Sangha Department (Republic of the Congo)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7b22e1e0b58b4dc85cad35894274a7bb",
+    "wof:geomhash":"49b5db6e711ba2c641e34ae038f3fe06",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -320,7 +322,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690865895,
+    "wof:lastmodified":1695884904,
     "wof:name":"Sangha",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/41/85670041.geojson
+++ b/data/856/700/41/85670041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.834605,
-    "geom:area_square_m":34976646859.773865,
+    "geom:area_square_m":34976647276.359367,
     "geom:bbox":"13.868026,-4.922633,16.215223,-2.714159",
     "geom:latitude":-3.685888,
     "geom:longitude":15.02139,
@@ -295,17 +295,19 @@
         "gn:id":2255404,
         "gp:id":2344975,
         "hasc:id":"CG.PO",
+        "iso:code":"CG-12",
         "iso:id":"CG-12",
         "qs_pg:id":235569,
         "unlc:id":"CG-12",
         "wd:id":"Q864647",
         "wk:page":"Pool Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5afaf8db3fe41cc96ed0bf2eeebfffaf",
+    "wof:geomhash":"ce13f60fd2c6ab1f70b2077a61a78e0e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -320,7 +322,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690865897,
+    "wof:lastmodified":1695884905,
     "wof:name":"Pool",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/45/85670045.geojson
+++ b/data/856/700/45/85670045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.210924,
-    "geom:area_square_m":39701078733.461563,
+    "geom:area_square_m":39701078006.485031,
     "geom:bbox":"14.887058,-1.594799,17.483142,0.467351",
     "geom:latitude":-0.472315,
     "geom:longitude":16.17043,
@@ -303,16 +303,18 @@
         "gn:id":2260487,
         "gp:id":2344968,
         "hasc:id":"CG.CU",
+        "iso:code":"CG-8",
         "iso:id":"CG-8",
         "qs_pg:id":1142809,
         "wd:id":"Q780884",
         "wk:page":"Cuvette Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9e8fd4637750903b2c44587c5c052141",
+    "wof:geomhash":"316bf4c8132991dabd1dd9e3d0f175b1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -327,7 +329,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690865896,
+    "wof:lastmodified":1695884905,
     "wof:name":"Cuvette",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/49/85670049.geojson
+++ b/data/856/700/49/85670049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.106545,
-    "geom:area_square_m":13645224400.654467,
+    "geom:area_square_m":13645225619.564108,
     "geom:bbox":"11.153242,-5.031389,12.782306,-3.493891",
     "geom:latitude":-4.226273,
     "geom:longitude":11.939515,
@@ -232,16 +232,18 @@
         "gn:id":2258738,
         "gp:id":2344969,
         "hasc:id":"CG.KL",
+        "iso:code":"CG-5",
         "iso:id":"CG-5",
         "qs_pg:id":220133,
         "wd:id":"Q855327",
         "wk:page":"Kouilou Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"77c20e76e677308b63f6346e602da6d2",
+    "wof:geomhash":"03abf507e32034e3f991d4ae2d227e92",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -256,7 +258,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690865899,
+    "wof:lastmodified":1695884906,
     "wof:name":"Kouilou",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/53/85670053.geojson
+++ b/data/856/700/53/85670053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.705315,
-    "geom:area_square_m":21054984344.044292,
+    "geom:area_square_m":21054985202.139198,
     "geom:bbox":"12.599731,-4.056546,14.345455,-2.088873",
     "geom:latitude":-3.104871,
     "geom:longitude":13.49739,
@@ -301,17 +301,19 @@
         "gn:id":2258534,
         "gp:id":2344970,
         "hasc:id":"CG.LE",
+        "iso:code":"CG-2",
         "iso:id":"CG-2",
         "qs_pg:id":1134978,
         "unlc:id":"CG-2",
         "wd:id":"Q862753",
         "wk:page":"L\u00e9koumou Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0a9d3558e883fb09686ea51100f3d592",
+    "wof:geomhash":"91718bb9e38fb73f0b07fc2a54d64460",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690865897,
+    "wof:lastmodified":1695884365,
     "wof:name":"L\u00e9koumou",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/59/85670059.geojson
+++ b/data/856/700/59/85670059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.250066,
-    "geom:area_square_m":27778928057.433453,
+    "geom:area_square_m":27778927646.502632,
     "geom:bbox":"11.518748,-4.916207,13.58,-1.812376",
     "geom:latitude":-3.135053,
     "geom:longitude":12.460717,
@@ -296,17 +296,19 @@
         "gn:id":2256175,
         "gp:id":2344972,
         "hasc:id":"CG.NI",
+        "iso:code":"CG-9",
         "iso:id":"CG-9",
         "qs_pg:id":235570,
         "unlc:id":"CG-9",
         "wd:id":"Q969317",
         "wk:page":"Niari Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2873e184412288e3981d900d3af080b4",
+    "wof:geomhash":"7b16ee99c62a94b01615ad99f1393a0c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690865894,
+    "wof:lastmodified":1695884903,
     "wof:name":"Niari",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/63/85670063.geojson
+++ b/data/856/700/63/85670063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.225576,
-    "geom:area_square_m":39856609723.070351,
+    "geom:area_square_m":39856609211.686462,
     "geom:bbox":"14.116034,-3.085043,16.656969,-0.936762",
     "geom:latitude":-2.097627,
     "geom:longitude":15.390966,
@@ -298,17 +298,19 @@
         "gn:id":2255422,
         "gp:id":2344973,
         "hasc:id":"CG.PL",
+        "iso:code":"CG-14",
         "iso:id":"CG-14",
         "qs_pg:id":1142807,
         "unlc:id":"CG-14",
         "wd:id":"Q765370",
         "wk:page":"Plateaux Department (Republic of the Congo)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5c250cbf5f22fc5a5a189a9fca7561bd",
+    "wof:geomhash":"97bc9b1e9df5316d404641f7233414f7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690865897,
+    "wof:lastmodified":1695884905,
     "wof:name":"Plateaux",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/67/85670067.geojson
+++ b/data/856/700/67/85670067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009912,
-    "geom:area_square_m":122226676.08086,
+    "geom:area_square_m":122226124.226508,
     "geom:bbox":"15.213081,-4.321743,15.426754,-4.201672",
     "geom:latitude":-4.263854,
     "geom:longitude":15.283122,
@@ -598,16 +598,18 @@
         "gn:id":2572183,
         "gp:id":2344976,
         "hasc:id":"CG.BR",
+        "iso:code":"CG-BZV",
         "iso:id":"CG-BZV",
         "qs_pg:id":229365,
         "unlc:id":"CG-BZV",
         "wd:id":"Q3844"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"160079d47eaeb519d18e61dcaa5b2fb7",
+    "wof:geomhash":"833e5dcc1eccd433aa50f63e3d266feb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -622,7 +624,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690865895,
+    "wof:lastmodified":1695884365,
     "wof:name":"Brazzaville",
     "wof:parent_id":85632541,
     "wof:placetype":"region",

--- a/data/856/700/71/85670071.geojson
+++ b/data/856/700/71/85670071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003943,
-    "geom:area_square_m":48583610.631316,
+    "geom:area_square_m":48583502.719052,
     "geom:bbox":"11.821222,-4.830029,11.912168,-4.744209",
     "geom:latitude":-4.787165,
     "geom:longitude":11.871086,
@@ -249,17 +249,19 @@
         "gn:id":2258738,
         "gp:id":2344969,
         "hasc:id":"CG.PN",
+        "iso:code":"CG-16",
         "iso:id":"CG-16",
         "qs_pg:id":220133,
         "unlc:id":"CG-16",
         "wd:id":"Q855327",
         "wk:page":"Kouilou Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"46f7a0260c33503707bd4379403ad1cc",
+    "wof:geomhash":"81de82105e5f89965d9402c6c85a03ca",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -274,7 +276,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690865898,
+    "wof:lastmodified":1695884906,
     "wof:name":"Pointe Noire",
     "wof:parent_id":85632541,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.